### PR TITLE
Add support for migration dry runs.

### DIFF
--- a/lib/evolver.rb
+++ b/lib/evolver.rb
@@ -37,9 +37,9 @@ module Evolver
   # @return [ true ] True if all migrations succeeded.
   #
   # @since 0.0.0
-  def migrate
+  def migrate(options = {})
     load_migrations
-    Migrator.new(sessions).execute and true
+    Migrator.new(sessions, options).execute and true
   end
 
   # Load all the migrations in the application.

--- a/lib/evolver/tasks/db.rake
+++ b/lib/evolver/tasks/db.rake
@@ -6,6 +6,13 @@ namespace :evolver do
     Evolver.migrate
   end
 
+  namespace :migrate do
+    desc "Dry run of any pending MongoDB data migrations on all sessions."
+    task dry: :environment do
+      Evolver.migrate(dry: true)
+    end
+  end
+
   desc "Revert the last run MongoDB data migration."
   task revert: :environment do
     Evolver.revert

--- a/spec/evolver/migrator_spec.rb
+++ b/spec/evolver/migrator_spec.rb
@@ -6,17 +6,34 @@ describe Evolver::Migrator do
     Mongoid.default_session
   end
 
-  before(:all) do
+  before do
     session[:evolver_migrations].find.remove_all
   end
 
   describe "#execute" do
 
-    let(:migrator) do
-      described_class.new({ default: session })
+    context "dry run" do
+
+      let(:migrator) do
+        described_class.new({ default: session }, { dry: true })
+      end
+
+      before { migrator.execute }
+
+      let(:migrations) do
+        session[:evolver_migrations].find.sort(generated: 1).to_a
+      end
+
+      it "does not execute the migrations" do
+        migrations.count.should eq(0)
+      end
     end
 
     context "when no migrations have been run" do
+
+      let(:migrator) do
+        described_class.new({ default: session })
+      end
 
       before do
         session[:labels].insert({
@@ -28,11 +45,10 @@ describe Evolver::Migrator do
       end
 
       after do
-        session[:evolver_migrations].find.remove_all
         session[:labels].find.remove_all
       end
 
-      let!(:migrations) do
+      let(:migrations) do
         session[:evolver_migrations].find.sort(generated: 1).to_a
       end
 


### PR DESCRIPTION
In dry runs, only the execution order will be logged. No migrations will be executed or marked as executed. Unfortunately, Rake already uses --dry-run, so this is added as a separate task named "evolver:migrate:dry".

Let me know if you think this is useful. At work we ran into a few cases where we needed it (after a bunch of late, complex merges).
